### PR TITLE
use unsigned integers

### DIFF
--- a/lib/postgrex/pg_output/lsn.ex
+++ b/lib/postgrex/pg_output/lsn.ex
@@ -13,7 +13,7 @@ defmodule Postgrex.PgOutput.Lsn do
   @type t :: {non_neg_integer(), non_neg_integer()} | binary()
 
   @spec decode(binary()) :: t()
-  def decode(<<xlog_file::int32(), xlog_offset::int32()>>), do: {xlog_file, xlog_offset}
+  def decode(<<xlog_file::uint32(), xlog_offset::uint32()>>), do: {xlog_file, xlog_offset}
 
   @spec decode_string(binary()) :: t()
   def decode_string(lsn_string) do
@@ -31,7 +31,7 @@ defmodule Postgrex.PgOutput.Lsn do
 
   @spec encode_int64(t()) :: integer()
   def encode_int64({xlog_file, xlog_offset}) do
-    <<lsn::int64()>> = <<xlog_file::int32(), xlog_offset::int32()>>
+    <<lsn::uint64()>> = <<xlog_file::uint32(), xlog_offset::uint32()>>
     lsn
   end
 

--- a/test/postgrex/pg_output/lsn_test.exs
+++ b/test/postgrex/pg_output/lsn_test.exs
@@ -4,33 +4,32 @@ defmodule Postgrex.PgOutput.LsnTest do
 
   describe "encode/decode" do
     test "can decode lsn" do
-      assert dbg({0, 685_397_688}) == dbg(Lsn.decode(<<0, 0, 0, 0, 40, 218, 86, 184>>))
+      assert {0, 685_397_688} == Lsn.decode(<<0, 0, 0, 0, 40, 218, 86, 184>>)
     end
 
     test "can encode lsn" do
-      assert dbg(<<0, 0, 0, 0, 40, 218, 86, 184>>) == dbg(Lsn.encode({0, 685_397_688}))
+      assert <<0, 0, 0, 0, 40, 218, 86, 184>> == Lsn.encode({0, 685_397_688})
     end
 
     test "can decode string" do
-      assert dbg({0, 0}) == dbg(Lsn.decode_string("0/0"))
+      assert {0, 0} == Lsn.decode_string("0/0")
     end
 
     test "can decode string with offset" do
-      assert dbg({0, 685_397_688}) == dbg(Lsn.decode_string("0/28DA56B8"))
+      assert {0, 685_397_688} == Lsn.decode_string("0/28DA56B8")
     end
 
     test "can encode string" do
-      assert dbg("0/0") == dbg(Lsn.encode_string({0, 0}))
+      assert "0/0" == Lsn.encode_string({0, 0})
     end
 
     test "can encode string with offset" do
-      lsn = dbg("0/28DA56B8")
+      lsn = "0/28DA56B8"
 
       lsn2 =
         lsn
         |> Lsn.decode_string()
         |> Lsn.encode_string()
-        |> dbg()
 
       assert lsn == lsn2
     end

--- a/test/postgrex/pg_output/lsn_test.exs
+++ b/test/postgrex/pg_output/lsn_test.exs
@@ -4,34 +4,41 @@ defmodule Postgrex.PgOutput.LsnTest do
 
   describe "encode/decode" do
     test "can decode lsn" do
-      assert {0, 685_397_688} == Lsn.decode(<<0, 0, 0, 0, 40, 218, 86, 184>>)
+      assert dbg({0, 685_397_688}) == dbg(Lsn.decode(<<0, 0, 0, 0, 40, 218, 86, 184>>))
     end
 
     test "can encode lsn" do
-      assert <<0, 0, 0, 0, 40, 218, 86, 184>> == Lsn.encode({0, 685_397_688})
+      assert dbg(<<0, 0, 0, 0, 40, 218, 86, 184>>) == dbg(Lsn.encode({0, 685_397_688}))
     end
 
     test "can decode string" do
-      assert {0, 0} = Lsn.decode_string("0/0")
+      assert dbg({0, 0}) == dbg(Lsn.decode_string("0/0"))
     end
 
     test "can decode string with offset" do
-      assert {0, 685_397_688} = Lsn.decode_string("0/28DA56B8")
+      assert dbg({0, 685_397_688}) == dbg(Lsn.decode_string("0/28DA56B8"))
     end
 
     test "can encode string" do
-      assert "0/0" = Lsn.encode_string({0, 0})
+      assert dbg("0/0") == dbg(Lsn.encode_string({0, 0}))
     end
 
     test "can encode string with offset" do
-      lsn = "0/28DA56B8"
+      lsn = dbg("0/28DA56B8")
 
       lsn2 =
         lsn
         |> Lsn.decode_string()
         |> Lsn.encode_string()
+        |> dbg()
 
       assert lsn == lsn2
+    end
+
+    @tag :focus
+    test "can handle values in the unsigned range" do
+      assert Lsn.encode_int64({0, 4_294_967_295}) == 4_294_967_295
+      assert Lsn.decode(Lsn.encode({0, 4_294_967_295})) == Lsn.decode_string("0/FFFFFFFF")
     end
   end
 end


### PR DESCRIPTION
I think these values should be unsinged integers. We used it and got negative numbers. Which I don't think makes sense in the context of LSNs